### PR TITLE
Add netlify.toml with routing config

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,4 @@
+[[redirects]]
+from = "/*"
+to = "/"
+status = 200


### PR DESCRIPTION
It fixes not-found page reloading when using the router paths.